### PR TITLE
Support input images with more than 8bits per channel

### DIFF
--- a/cubemap_splitter/cubemap_splitter/image.py
+++ b/cubemap_splitter/cubemap_splitter/image.py
@@ -71,7 +71,7 @@ class Image:
             No image found at self.__path
         """
         print("Reading Image: %s" % self.__path)
-        self.__image_data = cv2.imread(self.__path)
+        self.__image_data = cv2.imread(self.__path, cv2.IMREAD_ANYCOLOR | cv2.IMREAD_ANYDEPTH)
         if self.__image_data is None:
             raise ImageNotFound("No image found at: " + self.__path)
 


### PR DESCRIPTION
When splitting a 16bit png cube map, the output files are 8bit png images. I have done a little fix to keep the input image original color depth. 